### PR TITLE
setup.py: update URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     scripts = ['bin/chacractl'],
     install_requires = ['tambo>=0.1.0', 'requests'],
     version = metadata['version'],
-    url = 'http://github.com/alfredodeza/chacractl',
+    url = 'https://github.com/ceph/chacractl',
     license = "MIT",
     zip_safe = False,
     keywords = "http api chacra",


### PR DESCRIPTION
Use the encrypted HTTPS URL to GitHub, and point at the new home (the
"ceph" org).