### PR TITLE
Project support

### DIFF
--- a/chacractl/api/projects.py
+++ b/chacractl/api/projects.py
@@ -1,0 +1,100 @@
+import logging
+import sys
+import os
+from textwrap import dedent
+
+import requests
+from tambo import Transport
+
+import chacractl
+
+logger = logging.getLogger(__name__)
+
+
+class Project(object):
+    _help = dedent("""
+    Handle projects on a remote chacra instance.
+
+    Creating a new project::
+
+        chacractl project create project
+
+    Options:
+
+    create        Creates a new project
+    """)
+    help_menu = "create projects"
+    options = ['create']
+
+    def __init__(self, argv):
+        self.argv = argv
+
+    @property
+    def base_url(self):
+        return os.path.join(
+            chacractl.config['url'], 'binaries'
+        )
+
+    def sanitize_url(self, url_part):
+        # get rid of the leading slash to prevent issues when joining
+        url = url_part.lstrip('/')
+
+        # and add a trailing slash so that the request is done at the correct
+        # canonical url
+        if not url.endswith('/'):
+            url = "%s/" % url
+        return url
+
+    def post(self, url):
+        exists = requests.head(url)
+
+        if exists.status_code == 200:
+            logger.warning('resource exists, will not upload')
+            logger.warning('SKIP %s', url)
+            return
+        elif exists.status_code == 404:
+            logger.info('POSTing to project: %s', url)
+            response = requests.post(
+                url,
+                auth=chacractl.config['credentials'])
+        if response.status_code > 201:
+            logger.warning("%s -> %s", response.status_code, response.text)
+            response.raise_for_status()
+
+    def delete(self, url):
+        # XXX This exists here but it is not yet implemented, e.g. nothing
+        # calls this method
+        exists = requests.head(url)
+        if exists.status_code == 404:
+            logger.warning('project already deleted')
+            logger.warning('SKIP %s', url)
+            return
+        logger.info('DELETE project: %s', url)
+        response = requests.delete(
+            url,
+            auth=chacractl.config['credentials'])
+        if response.status_code > 201:
+            logger.warning("%s -> %s", response.status_code, response.text)
+
+    def main(self):
+        self.parser = Transport(self.argv, options=self.options)
+        self.parser.catch_help = self._help
+        self.parser.parse_args()
+
+        # handle posting projects:
+        if self.parser.has('create'):
+            url_part = self.sanitize_url(self.parser.get('create'))
+            if not sys.stdin.isatty():
+                # read from stdin
+                logger.info('reading input from stdin')
+                for line in sys.stdin.readlines():
+                    url = os.path.join(self.base_url, url_part)
+                    self.post(url)
+            else:
+                url = os.path.join(self.base_url, url_part)
+                self.post(url)
+        # XXX this exists here but it not yet enabled from the CLI
+        elif self.parser.has('delete'):
+            url_part = self.sanitize_url(self.parser.get('delete'))
+            url = os.path.join(self.base_url, url_part)
+            self.delete(url)

--- a/chacractl/main.py
+++ b/chacractl/main.py
@@ -4,7 +4,7 @@ import sys
 
 from tambo import Transport
 import chacractl
-from chacractl.api import binaries, repos, exists
+from chacractl.api import binaries, repos, exists, projects
 from chacractl.decorators import catches
 from chacractl import log, util
 
@@ -26,6 +26,7 @@ Sub Commands:
 
     mapper = {
         'binary': binaries.Binary,
+        'project': projects.Project,
         'repo': repos.Repo,
         'exists': exists.Exists,
     }


### PR DESCRIPTION
Allows to create projects. The delete portion exists but is not fully implemented:

    chacractl project create myproject
    [requests.packages.urllib3.connectionpool][INFO  ] Starting new HTTPS connection (1): 192.168.111.100
    [requests.packages.urllib3.connectionpool][DEBUG ] "HEAD /binaries/myproject/ HTTP/1.1" 404 0
    [chacractl.api.projects][INFO  ] POSTing to project: https://192.168.111.100/binaries/myproject/
    [requests.packages.urllib3.connectionpool][INFO  ] Starting new HTTPS connection (1): 192.168.111.100
    [requests.packages.urllib3.connectionpool][DEBUG ] "POST /binaries/myproject/ HTTP/1.1" 200 2
