### PR TITLE
Flexible verification of SSL certificates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,7 @@ information::
     url = "http://example/"
     user = "admin"
     key = "secret"
+    ssl_verify = True
 
 These values need to be modified so that the CLI can interact with the remote
 API.

--- a/chacractl/api/binaries.py
+++ b/chacractl/api/binaries.py
@@ -59,7 +59,7 @@ class Binary(object):
     def post(self, url, filepath):
         filename = os.path.basename(filepath)
         file_url = os.path.join(url, filename) + '/'
-        exists = requests.head(file_url)
+        exists = requests.head(file_url, verify=chacractl.config['ssl_verify'])
 
         if exists.status_code == 200:
             if not self.force:
@@ -75,7 +75,8 @@ class Binary(object):
                 response = requests.post(
                     url,
                     files={'file': binary},
-                    auth=chacractl.config['credentials'])
+                    auth=chacractl.config['credentials'],
+                    verify=chacractl.config['ssl_verify'])
         if response.status_code > 201:
             logger.warning("%s -> %s", response.status_code, response.text)
             response.raise_for_status()
@@ -87,12 +88,13 @@ class Binary(object):
             response = requests.put(
                 url,
                 files={'file': binary},
-                auth=chacractl.config['credentials'])
+                auth=chacractl.config['credentials'],
+                verify=chacractl.config['ssl_verify'])
         if response.status_code > 201:
             logger.warning("%s -> %s", response.status_code, response.text)
 
     def delete(self, url):
-        exists = requests.head(url)
+        exists = requests.head(url, verify=chacractl.config['ssl_verify'])
         if exists.status_code == 404:
             logger.warning('resource already deleted')
             logger.warning('SKIP %s', url)
@@ -100,7 +102,8 @@ class Binary(object):
         logger.info('DELETE file: %s', url)
         response = requests.delete(
             url,
-            auth=chacractl.config['credentials'])
+            auth=chacractl.config['credentials'],
+            verify=chacractl.config['ssl_verify'])
         if response.status_code > 201:
             logger.warning("%s -> %s", response.status_code, response.text)
 

--- a/chacractl/api/exists.py
+++ b/chacractl/api/exists.py
@@ -46,7 +46,8 @@ class Exists(object):
         logger.info('HEAD: %s', url)
         exists = requests.head(
             url,
-            auth=chacractl.config['credentials'])
+            auth=chacractl.config['credentials'],
+            verify=chacractl.config['ssl_verify'])
         exists.raise_for_status()
 
     def main(self):

--- a/chacractl/api/projects.py
+++ b/chacractl/api/projects.py
@@ -46,7 +46,7 @@ class Project(object):
         return url
 
     def post(self, url):
-        exists = requests.head(url)
+        exists = requests.head(url, verify=chacractl.config['ssl_verify'])
 
         if exists.status_code == 200:
             logger.warning('resource exists, will not upload')
@@ -56,7 +56,8 @@ class Project(object):
             logger.info('POSTing to project: %s', url)
             response = requests.post(
                 url,
-                auth=chacractl.config['credentials'])
+                auth=chacractl.config['credentials'],
+                verify=chacractl.config['ssl_verify'])
         if response.status_code > 201:
             logger.warning("%s -> %s", response.status_code, response.text)
             response.raise_for_status()
@@ -64,7 +65,7 @@ class Project(object):
     def delete(self, url):
         # XXX This exists here but it is not yet implemented, e.g. nothing
         # calls this method
-        exists = requests.head(url)
+        exists = requests.head(url, verify=chacractl.config['ssl_verify'])
         if exists.status_code == 404:
             logger.warning('project already deleted')
             logger.warning('SKIP %s', url)
@@ -72,7 +73,8 @@ class Project(object):
         logger.info('DELETE project: %s', url)
         response = requests.delete(
             url,
-            auth=chacractl.config['credentials'])
+            auth=chacractl.config['credentials'],
+            verify=chacractl.config['ssl_verify'])
         if response.status_code > 201:
             logger.warning("%s -> %s", response.status_code, response.text)
 

--- a/chacractl/api/repos.py
+++ b/chacractl/api/repos.py
@@ -39,12 +39,14 @@ class Repo(object):
     def post(self, url):
         exists = requests.head(
             url,
-            auth=chacractl.config['credentials'])
+            auth=chacractl.config['credentials'],
+            verify=chacractl.config['ssl_verify'])
         exists.raise_for_status()
         logger.info('POST: %s', url)
         response = requests.post(
             url,
-            auth=chacractl.config['credentials'])
+            auth=chacractl.config['credentials'],
+            verify=chacractl.config['ssl_verify'])
         response.raise_for_status()
         json = response.json()
         for k, v in json.items():

--- a/chacractl/main.py
+++ b/chacractl/main.py
@@ -52,6 +52,7 @@ Sub Commands:
             user, key = conf_module.user, conf_module.key
         chacractl.config['credentials'] = (user, key)
         chacractl.config['url'] = conf_module.url
+        chacractl.config['ssl_verify'] = conf_module.ssl_verify
 
     @catches((RuntimeError, KeyboardInterrupt))
     def main(self, argv):

--- a/chacractl/util.py
+++ b/chacractl/util.py
@@ -33,6 +33,7 @@ def ensure_default_config():
     url = "http://example"
     user = "chacra user"
     key = "secret"
+    ssl_verify = True
     """)
     config = default_config_path()
     if not os.path.exists(config):


### PR DESCRIPTION
Adds `ssl_verify` option to configuration file and passes value
through to the `requests` library as the `verify` keyword option.
Defaults to original behavior (`ssl_verify = True`); other options:
- `False` for no verification; prints a warning
- a path to a trusted certificate/CA bundle