### PR TITLE
tests: reset "chacractl" config before every test

### DIFF
--- a/chacractl/tests/conftest.py
+++ b/chacractl/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_config(request):
+    sys.modules.pop('chacractl', None)


### PR DESCRIPTION
In the following scenario:

1. `imp.load_path()` is called with a `.chacractl` config file that contains a variable `foo`,

2. `imp.load_path()` is called again, this time with a `.chacractl` config file that does not contain the variable `foo`,

Then the `foo` variable will persist in the returned module from step 2 above.  In other words, `load_path()` only refreshes variables that have changed values, not ones that go missing altogether.

This problem shows up when testing different `.chacractl` files in a test suite. It creates a dependency on test ordering: tests that check for missing config values might accidentally pass because a previous test has already "created" the missing values in the loaded chacractl module.  There are no tests yet that check different `.chacractl` files, but they are coming in https://github.com/ceph/chacractl/pull/14

The way to make this consistent is to unload the module entirely (by deleting it from `sys.modules`) before loading it again with `imp.load_path()`.