### PR TITLE
.travis.yml: install chacractl and dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ python:
     - 3.4
     - 3.5
 script:
+  - python setup.py develop
   - py.test -v chacractl/tests
 cache: pip


### PR DESCRIPTION
The dependencies need to be in the virtualenv in order to run tests that load e.g. `chacractl/main.py`.