### PR TITLE
Verify checksums of uploaded binaries

### DIFF
--- a/chacractl/api/binaries.py
+++ b/chacractl/api/binaries.py
@@ -98,13 +98,13 @@ class Binary(object):
         if not self.verify_upload(url, filename, digest):
             # Since this is a new file, attempt to delete it
             logging.error(
-                    'Checksum mismatch: server has wrong checksum for %s! '
-                    'Deleting corrupted file from server...',
+                    'Checksum mismatch: server has wrong checksum for %s!',
                     filepath)
+            logging.error('Deleting corrupted file from server...')
             self.delete(file_url)
             raise SystemExit(
-                    'Checksum mismatch: server has wrong checksum for %s! '
-                    'Deleting corrupted file from server...' % filepath)
+                    'Checksum mismatch: server has wrong checksum for %s!'
+                    % filepath)
 
     def put(self, url, filepath):
         filename = os.path.basename(filepath)

--- a/chacractl/api/binaries.py
+++ b/chacractl/api/binaries.py
@@ -1,7 +1,6 @@
 import logging
 import sys
 import os
-import posixpath
 from textwrap import dedent
 from hashlib import sha512
 

--- a/chacractl/api/binaries.py
+++ b/chacractl/api/binaries.py
@@ -102,7 +102,9 @@ class Binary(object):
                     'Deleting corrupted file from server...',
                     filepath)
             self.delete(file_url)
-            raise SystemExit('Uploaded file checksum mismatch!')
+            raise SystemExit(
+                    'Checksum mismatch: server has wrong checksum for %s! '
+                    'Deleting corrupted file from server...' % filepath)
 
     def put(self, url, filepath):
         filename = os.path.basename(filepath)
@@ -119,7 +121,9 @@ class Binary(object):
         if not self.verify_upload(url, filename, digest):
             # Maybe the old file with a different digest is still there, so
             # don't delete it
-            raise SystemExit('Uploaded file checksum mismatch!')
+            raise SystemExit(
+                    'Checksum mismatch: server has wrong checksum for %s!'
+                    % filepath)
 
     def delete(self, url):
         exists = requests.head(url, verify=chacractl.config['ssl_verify'])

--- a/chacractl/api/binaries.py
+++ b/chacractl/api/binaries.py
@@ -98,6 +98,10 @@ class Binary(object):
             response.raise_for_status()
         if not self.verify_upload(url, filename, digest):
             # Since this is a new file, attempt to delete it
+            logging.error(
+                    'Checksum mismatch: server has wrong checksum for %s! '
+                    'Deleting corrupted file from server...',
+                    filepath)
             self.delete(file_url)
             raise SystemExit('Uploaded file checksum mismatch!')
 

--- a/chacractl/api/binaries.py
+++ b/chacractl/api/binaries.py
@@ -65,7 +65,7 @@ class Binary(object):
         binary.seek(0)
         return binary, chsum.hexdigest()
 
-    def verify_upload(arch_url, filename, digest):
+    def upload_is_verified(arch_url, filename, digest):
         r = requests.get(arch_url, verify=chacractl.config['ssl_verify'])
         r.raise_for_status()
         arch_data = r.json()
@@ -95,7 +95,7 @@ class Binary(object):
         if response.status_code > 201:
             logger.warning("%s -> %s", response.status_code, response.text)
             response.raise_for_status()
-        if not self.verify_upload(url, filename, digest):
+        if not self.upload_is_verified(url, filename, digest):
             # Since this is a new file, attempt to delete it
             logging.error(
                     'Checksum mismatch: server has wrong checksum for %s!',
@@ -118,7 +118,7 @@ class Binary(object):
                 verify=chacractl.config['ssl_verify'])
         if response.status_code > 201:
             logger.warning("%s -> %s", response.status_code, response.text)
-        if not self.verify_upload(url, filename, digest):
+        if not self.upload_is_verified(url, filename, digest):
             # Maybe the old file with a different digest is still there, so
             # don't delete it
             raise SystemExit(

--- a/chacractl/api/binaries.py
+++ b/chacractl/api/binaries.py
@@ -87,11 +87,12 @@ class Binary(object):
         elif exists.status_code == 404:
             logger.info('POSTing file: %s', filepath)
             binary, digest = self.load_file(filepath)
-            response = requests.post(
-                    url,
-                    files={'file': binary},
-                    auth=chacractl.config['credentials'],
-                    verify=chacractl.config['ssl_verify'])
+            with binary:
+                response = requests.post(
+                        url,
+                        files={'file': binary},
+                        auth=chacractl.config['credentials'],
+                        verify=chacractl.config['ssl_verify'])
         if response.status_code > 201:
             logger.warning("%s -> %s", response.status_code, response.text)
             response.raise_for_status()
@@ -111,11 +112,12 @@ class Binary(object):
         logger.info('resource exists and --force was used, will re-upload')
         logger.info('PUTing file: %s', filepath)
         binary, digest = self.load_file(filepath)
-        response = requests.put(
-                url,
-                files={'file': binary},
-                auth=chacractl.config['credentials'],
-                verify=chacractl.config['ssl_verify'])
+        with binary:
+            response = requests.put(
+                    url,
+                    files={'file': binary},
+                    auth=chacractl.config['credentials'],
+                    verify=chacractl.config['ssl_verify'])
         if response.status_code > 201:
             logger.warning("%s -> %s", response.status_code, response.text)
         if not self.upload_is_verified(url, filename, digest):


### PR DESCRIPTION
When a new binary is uploaded, read back the sha512sums computed by the
chacra server and ensure they match what's on the filesystem. If the
binary was not overwriting another of the same path and name, attempt to
delete it if the sums don't match.