### PR TITLE
trim filename when verifying checksum on a binary PUT

### DIFF
--- a/chacractl/api/binaries.py
+++ b/chacractl/api/binaries.py
@@ -120,6 +120,8 @@ class Binary(object):
                     verify=chacractl.config['ssl_verify'])
         if response.status_code > 201:
             logger.warning("%s -> %s", response.status_code, response.text)
+        # trim off binary filename
+        url = url.rsplit('/', 2)[0] + "/"
         if not self.upload_is_verified(url, filename, digest):
             # Maybe the old file with a different digest is still there, so
             # don't delete it


### PR DESCRIPTION
A PUT request must include the binary filename so it can be overwritten,
however if we want to verify the checksum we need to trim that filename
and issue a GET to the arch endpoint to retrieve the metadata for the
binary.

Fixes: https://github.com/ceph/chacractl/issues/29

Signed-off-by: Andrew Schoen <aschoen@redhat.com>