### PR TITLE
api/binaries: reference filename not filepath if digest does not match

### DIFF
--- a/chacractl/api/binaries.py
+++ b/chacractl/api/binaries.py
@@ -74,7 +74,7 @@ class Binary(object):
         if not verified:
             logging.error(
                     'Checksum mismatch: server has wrong checksum for %s',
-                    filepath)
+                    filename)
             logging.error('local checksum: %s', digest)
             logging.error('remote checksum: %s', remote_digest)
         return verified


### PR DESCRIPTION
otherwise a backtrace is ahead in this case.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>