### PR TITLE
Retry on failed requests

### DIFF
--- a/chacractl/api/binaries.py
+++ b/chacractl/api/binaries.py
@@ -5,9 +5,11 @@ from textwrap import dedent
 from hashlib import sha512
 
 import requests
+
 from tambo import Transport
 
 import chacractl
+from chacractl.util import retry
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +67,7 @@ class Binary(object):
         binary.seek(0)
         return binary, chsum.hexdigest()
 
+    @retry()
     def upload_is_verified(self, arch_url, filename, digest):
         r = requests.get(arch_url, verify=chacractl.config['ssl_verify'])
         r.raise_for_status()
@@ -79,6 +82,7 @@ class Binary(object):
             logging.error('remote checksum: %s', remote_digest)
         return verified
 
+    @retry()
     def post(self, url, filepath):
         filename = os.path.basename(filepath)
         file_url = os.path.join(url, filename) + '/'
@@ -111,7 +115,7 @@ class Binary(object):
             raise SystemExit(
                     'Checksum mismatch: remote server has wrong checksum for %s'
                     % filepath)
-
+    @retry()
     def put(self, url, filepath):
         filename = os.path.basename(filepath)
         logger.info('resource exists and --force was used, will re-upload')
@@ -133,7 +137,7 @@ class Binary(object):
             raise SystemExit(
                     'Checksum mismatch: server has wrong checksum for %s!'
                     % filepath)
-
+    @retry()
     def delete(self, url):
         exists = requests.head(url, verify=chacractl.config['ssl_verify'])
         if exists.status_code == 404:

--- a/chacractl/api/exists.py
+++ b/chacractl/api/exists.py
@@ -4,6 +4,7 @@ import logging
 import requests
 from tambo import Transport
 import chacractl
+from chacractl.util import retry
 from chacractl.decorators import catches, requests_errors
 
 
@@ -42,6 +43,7 @@ class Exists(object):
         return url
 
     @catches(requests.exceptions.HTTPError, handler=requests_errors)
+    @retry()
     def head(self, url):
         logger.info('HEAD: %s', url)
         exists = requests.head(

--- a/chacractl/api/projects.py
+++ b/chacractl/api/projects.py
@@ -7,6 +7,7 @@ import requests
 from tambo import Transport
 
 import chacractl
+from chacractl.util import retry
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +46,7 @@ class Project(object):
             url = "%s/" % url
         return url
 
+    @retry()
     def post(self, url):
         exists = requests.head(url, verify=chacractl.config['ssl_verify'])
 
@@ -62,6 +64,7 @@ class Project(object):
             logger.warning("%s -> %s", response.status_code, response.text)
             response.raise_for_status()
 
+    @retry()
     def delete(self, url):
         # XXX This exists here but it is not yet implemented, e.g. nothing
         # calls this method

--- a/chacractl/api/repos.py
+++ b/chacractl/api/repos.py
@@ -4,6 +4,7 @@ import logging
 import requests
 from tambo import Transport
 import chacractl
+from chacractl.util import retry
 from chacractl.decorators import catches, requests_errors
 
 
@@ -36,6 +37,7 @@ class Repo(object):
         )
 
     @catches(requests.exceptions.HTTPError, handler=requests_errors)
+    @retry()
     def post(self, url):
         exists = requests.head(
             url,


### PR DESCRIPTION
Because requests's way of doing it (requiring modifying the urllib3 session) is horrendous 