### PR TITLE
api.binaries prevent OverflowError with POST or PUT requests

### DIFF
--- a/chacractl/api/binaries.py
+++ b/chacractl/api/binaries.py
@@ -1,7 +1,10 @@
 import logging
 import sys
 import os
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 from textwrap import dedent
 from hashlib import sha512
 

--- a/chacractl/api/binaries.py
+++ b/chacractl/api/binaries.py
@@ -104,7 +104,7 @@ class Binary(object):
             binary, digest = self.load_file(filepath)
             response = requests.post(
                 url,
-                files={'file': binary},
+                files={'file': (filename, binary)},
                 auth=chacractl.config['credentials'],
                 verify=chacractl.config['ssl_verify'])
             if response.status_code > 201:
@@ -125,7 +125,7 @@ class Binary(object):
         binary, digest = self.load_file(filepath)
         response = requests.put(
             url,
-            files={'file': binary},
+            files={'file': (filename, binary)},
             auth=chacractl.config['credentials'],
             verify=chacractl.config['ssl_verify'])
         if response.status_code > 201:

--- a/chacractl/api/binaries.py
+++ b/chacractl/api/binaries.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import os
+from StringIO import StringIO
 from textwrap import dedent
 from hashlib import sha512
 
@@ -62,10 +63,12 @@ class Binary(object):
     def load_file(self, filepath):
         chsum = sha512()
         binary = open(filepath, 'rb')
-        for chunk in iter(lambda: binary.read(4096), b''):
-            chsum.update(chunk)
-        binary.seek(0)
-        return binary, chsum.hexdigest()
+        with open(filepath, 'rb') as binary:
+            for chunk in iter(lambda: binary.read(4096), b''):
+                chsum.update(chunk)
+            binary.seek(0)
+            binary_obj = StringIO(binary.read())
+        return binary_obj, chsum.hexdigest()
 
     @retry()
     def upload_is_verified(self, arch_url, filename, digest):
@@ -99,15 +102,14 @@ class Binary(object):
         elif exists.status_code == 404:
             logger.info('POSTing file: %s', filepath)
             binary, digest = self.load_file(filepath)
-            with binary:
-                response = requests.post(
-                        url,
-                        files={'file': binary},
-                        auth=chacractl.config['credentials'],
-                        verify=chacractl.config['ssl_verify'])
-                if response.status_code > 201:
-                    logger.warning("%s -> %s", response.status_code, response.text)
-                    response.raise_for_status()
+            response = requests.post(
+                url,
+                files={'file': binary},
+                auth=chacractl.config['credentials'],
+                verify=chacractl.config['ssl_verify'])
+            if response.status_code > 201:
+                logger.warning("%s -> %s", response.status_code, response.text)
+                response.raise_for_status()
         if not self.upload_is_verified(url, filename, digest):
             # Since this is a new file, attempt to delete it
             logging.error('Deleting corrupted file from server...')
@@ -121,12 +123,11 @@ class Binary(object):
         logger.info('resource exists and --force was used, will re-upload')
         logger.info('PUTing file: %s', filepath)
         binary, digest = self.load_file(filepath)
-        with binary:
-            response = requests.put(
-                    url,
-                    files={'file': binary},
-                    auth=chacractl.config['credentials'],
-                    verify=chacractl.config['ssl_verify'])
+        response = requests.put(
+            url,
+            files={'file': binary},
+            auth=chacractl.config['credentials'],
+            verify=chacractl.config['ssl_verify'])
         if response.status_code > 201:
             logger.warning("%s -> %s", response.status_code, response.text)
         # trim off binary filename

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
         'Topic :: Utilities',
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: POSIX',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist =  py26, py27, py33
+envlist = py27, py33
 
 [testenv]
 deps =


### PR DESCRIPTION
Before the object was fully read in memory and passed through
``requests`` which in turn treated it like a string. For Ceph Debug
packages, this means the OverflowError would come up if the package was
over 2GB in size.

With this changes, I was able to POST a 3GB binary file
