### PR TITLE
.travis.yml: run tox with tox-travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@ language: python
 sudo: false
 python:
     - 2.7
-    - 3.3
-    - 3.4
-    - 3.5
-script:
-  - python setup.py develop
-  - py.test -v chacractl/tests
+    - 3.6
+install: pip install tox-travis
+script: tox
 cache: pip


### PR DESCRIPTION
Use tox-travis to test in Travis CI, instead of relying on setuptools/distutils to pull in our dependencies.

This change also aligns Travis CI's Python versions with what is in tox.ini.