### PR TITLE
api: should not append "delete" in the url for delete

### DIFF
--- a/chacractl/api/repos.py
+++ b/chacractl/api/repos.py
@@ -86,6 +86,6 @@ class Repo(object):
             url = os.path.join(self.base_url, url_part)
             self.post(url)
         elif delete:
-            url_part = os.path.join(delete, 'delete')
+            url_part = delete
             url = os.path.join(self.base_url, url_part)
             self.delete(url)


### PR DESCRIPTION
we are using the RepoController.index_delete() for deleting a repo,
which is mapped from "HTTP DELETE /<repo-id>/", instead of "HTTP GET
/<repo-id>/delete". so should not add "delete" as the last component of
the URL.

see
https://pecan.readthedocs.io/en/latest/rest.html?highlight=delete#url-mapping,

Signed-off-by: Kefu Chai <tchaikov@gmail.com>