### PR TITLE
Changes for py3, along with an inexplicable fix to test_main.py

### DIFF
--- a/chacractl/tests/test_main.py
+++ b/chacractl/tests/test_main.py
@@ -25,6 +25,6 @@ class TestApiCredentials(object):
         config_path = tmpdir.join('.chacractl')
         config_path.write(template)
         monkeypatch.setattr(os.path, 'expanduser', lambda _: str(config_path))
-        c = ChacraCtl()
+        c = ChacraCtl(parse=False)
         c.api_credentials()
         assert chacractl.config['ssl_verify'] == expected

--- a/chacractl/util.py
+++ b/chacractl/util.py
@@ -1,4 +1,5 @@
-import imp
+import importlib.util
+import importlib.machinery
 import os
 from textwrap import dedent
 from requests.exceptions import BaseHTTPError, RequestException
@@ -21,11 +22,22 @@ def get_config_path():
         return config
 
 
+# replace imp.load_source as documented in
+# https://docs.python.org/3/whatsnew/3.12.html#imp
+
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
 def load_config():
     config = get_config_path()
     if not config:
         return
-    return imp.load_source('chacractl', config)
+    return load_source('chacractl', config)
 
 
 def ensure_default_config():

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author = 'Alfredo Deza',
     author_email = 'adeza@redhat.com',
     scripts = ['bin/chacractl'],
-    install_requires = ['tambo>=0.1.0', 'requests', 'requests-toolbelt==0.9.1'],
+    install_requires = ['tambo>=0.1.0', 'requests', 'requests-toolbelt'],
     version = metadata['version'],
     url = 'https://github.com/ceph/chacractl',
     license = "MIT",
@@ -28,8 +28,9 @@ setup(
         'Topic :: Utilities',
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: POSIX',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     tests_require=[
         'pytest'

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,8 @@
 [tox]
-envlist = py27, py36
+envlist = py310, py311, py312
 
 [testenv]
 deps =
     pytest
-[testenv:py26]
-deps =
-    argparse
-    pytest
 
-commands = py.test
+commands = pytest


### PR DESCRIPTION
I don't see how test_main ever called ChacraCtl() with no args, but this fixes the test.  Otherwise, unpin a dependency, replace 'imp' with 'importlib', change tox env list.  Resultant binary seems to work on simple 'exists' commands, various help, and passes tox.
